### PR TITLE
Update index-en.html

### DIFF
--- a/OnToology/ontology/agenda-municipal.owl/documentation/index-en.html
+++ b/OnToology/ontology/agenda-municipal.owl/documentation/index-en.html
@@ -64,7 +64,15 @@ function loadTOC(){
 
 <dl>
 <dt>This version:</dt>
-<dd><a href="http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal">http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/1.0.1</a></dd>
+<dd><a href="http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/index-en.html">http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/1.0.1</a></dd>
+<dl>
+<dt>Previous version:</dt>
+<dd><a href="http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/1.0.0/index-en.html">http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/1.0.0</a></dd>
+<dl>
+<dt>Latest version:</dt>
+<dd><a href="http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/index-en.html">http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/</a></dd>
+
+	
 <dt>Authors:</dt>
 <dd>Edna Ruckhaus (Ontology Engineering Group - Universidad Politécnica de Madrid)</dd><dd>Oscar Corcho (Ontology Engineering Group - Universidad Politécnica de Madrid, Localidata)</dd><dd>Paola Espinoza Arias (Ontology Engineering Group - Universidad Politécnica de Madrid)</dd>
 


### PR DESCRIPTION
- Changed version format to show This version, Previous version and Latest version. In future versions we will mantain the version scale when adding a new one

- English version was incorrectly pointing to spanish version. Added manually index-en.html to avoid this issue.

Changes made manually in the webserver, can be seen http://vocab.ciudadesabiertas.es/def/sector-publico/agenda-municipal/index-en.html